### PR TITLE
Illustrate generating isolated JaCoCo reports for different Surefire goal executions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -140,9 +140,25 @@
                         </goals>
                         <phase>initialize</phase>
                         <configuration>
-                            <propertyName>jacoco-agent.unit-test</propertyName>
-                            <destFile>${project.build.directory}/jacoco-unit-test.exec</destFile>
+                            <propertyName>jacoco-agent.unit-tests</propertyName>
+                            <destFile>${project.build.directory}/jacoco-unit-tests.exec</destFile>
                         </configuration>
+                    </execution>
+                    <!-- generate coverage report for unit-tests -->
+                    <execution>
+                        <id>generate-unit-tests-coverage</id>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                        <configuration>
+                            <dataFile>${project.build.directory}/jacoco-unit-tests.exec</dataFile>
+                            <outputDirectory>${project.reporting.outputDirectory}/jacoco-unit-test-coverage-report</outputDirectory>
+                        </configuration>
+                    </execution>
+                    <!-- disable JaCoCo report for surefire:test@default-test -->
+                    <execution>
+                        <id>jacoco-report</id>
+                        <phase>none</phase>
                     </execution>
                     <!-- prepare JaCoCo agent for surefire:test@integration-test -->
                     <execution>
@@ -152,8 +168,19 @@
                         </goals>
                         <phase>pre-integration-test</phase>
                         <configuration>
-                            <propertyName>jacoco-agent.integration-test</propertyName>
-                            <destFile>${project.build.directory}/jacoco-integration-test.exec</destFile>
+                            <propertyName>jacoco-agent.integration-tests</propertyName>
+                            <destFile>${project.build.directory}/jacoco-integration-tests.exec</destFile>
+                        </configuration>
+                    </execution>
+                    <!-- generate coverage report for integration-tests -->
+                    <execution>
+                        <id>generate-integration-tests-coverage</id>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                        <configuration>
+                            <dataFile>${project.build.directory}/jacoco-integration-tests.exec</dataFile>
+                            <outputDirectory>${project.reporting.outputDirectory}/jacoco-integration-test-coverage-report</outputDirectory>
                         </configuration>
                     </execution>
                 </executions>
@@ -176,7 +203,7 @@
                                 <exclude>**/*IT.java</exclude>
                             </excludes>
                             <!-- use JaCoCo agent configuration specific to unit tests -->
-                            <argLine>${jacoco-agent.unit-test}</argLine>
+                            <argLine>${jacoco-agent.unit-tests}</argLine>
                         </configuration>
                         <goals>
                             <goal>test</goal>
@@ -190,7 +217,7 @@
                                 <include>**/*IT.java</include>
                             </includes>
                             <!-- use JaCoCo agent configuration specific to integration tests -->
-                            <argLine>${jacoco-agent.integration-test}</argLine>
+                            <argLine>${jacoco-agent.integration-tests}</argLine>
                         </configuration>
                         <goals>
                             <goal>test</goal>

--- a/pom.xml
+++ b/pom.xml
@@ -132,30 +132,29 @@
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
                 <executions>
+                    <!-- prepare JaCoCo agent for surefire:test@unit-test -->
                     <execution>
-                        <id>default-prepare-agent</id>
+                        <id>unit-prepare-agent</id>
                         <goals>
                             <goal>prepare-agent</goal>
                         </goals>
-<!--                        <configuration>-->
-<!--                            <destFile>${project.build.directory}/jacoco-default.exec</destFile>-->
-<!--                        </configuration>-->
+                        <phase>initialize</phase>
+                        <configuration>
+                            <propertyName>jacoco-agent.unit-test</propertyName>
+                            <destFile>${project.build.directory}/jacoco-unit-test.exec</destFile>
+                        </configuration>
                     </execution>
+                    <!-- prepare JaCoCo agent for surefire:test@integration-test -->
                     <execution>
                         <id>integration-prepare-agent</id>
                         <goals>
                             <goal>prepare-agent</goal>
                         </goals>
                         <phase>pre-integration-test</phase>
-<!--                        <configuration>-->
-<!--                            <destFile>${project.build.directory}/jacoco-integration.exec</destFile>-->
-<!--                        </configuration>-->
-                    </execution>
-                    <execution>
-                        <id>report</id>
-                        <goals>
-                            <goal>report</goal>
-                        </goals>
+                        <configuration>
+                            <propertyName>jacoco-agent.integration-test</propertyName>
+                            <destFile>${project.build.directory}/jacoco-integration-test.exec</destFile>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>
@@ -165,13 +164,19 @@
                 <version>2.22.2</version>
                 <executions>
                     <execution>
+                        <id>default-test</id>
+                        <!-- this executes the same tests as unit-tests -->
+                        <phase>none</phase>
+                    </execution>
+                    <execution>
                         <id>unit-tests</id>
                         <phase>test</phase>
                         <configuration>
-
                             <excludes>
                                 <exclude>**/*IT.java</exclude>
                             </excludes>
+                            <!-- use JaCoCo agent configuration specific to unit tests -->
+                            <argLine>${jacoco-agent.unit-test}</argLine>
                         </configuration>
                         <goals>
                             <goal>test</goal>
@@ -181,10 +186,11 @@
                         <id>integration-tests</id>
                         <phase>integration-test</phase>
                         <configuration>
-
                             <includes>
                                 <include>**/*IT.java</include>
                             </includes>
+                            <!-- use JaCoCo agent configuration specific to integration tests -->
+                            <argLine>${jacoco-agent.integration-test}</argLine>
                         </configuration>
                         <goals>
                             <goal>test</goal>

--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
             <scope>test</scope>

--- a/src/test/java/com/soebes/example/jacoco/FirstIT.java
+++ b/src/test/java/com/soebes/example/jacoco/FirstIT.java
@@ -19,18 +19,18 @@ package com.soebes.example.jacoco;
  * under the License.
  */
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import org.junit.jupiter.api.Test;
 
-class FirstIT {
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class FirstIT {
 
     @Test
-  void first_minus() {
-    First sum1 = new First(5);
-    First sum2 = new First(2);
-      First sum3 = new First(22212231);
+    public void first_minus() {
+        First sum1 = new First(5);
+        First sum2 = new First(2);
+        First sum3 = new First(22212231);
 
-    assertThat(sum1.minus(sum2)).isEqualTo(new First(3));
-  }
+        assertThat(sum1.minus(sum2)).isEqualTo(new First(3));
+    }
 }

--- a/src/test/java/com/soebes/example/jacoco/FirstTest.java
+++ b/src/test/java/com/soebes/example/jacoco/FirstTest.java
@@ -19,14 +19,14 @@ package com.soebes.example.jacoco;
  * under the License.
  */
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import org.junit.jupiter.api.Test;
 
-class FirstTest {
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class FirstTest {
 
     @Test
-    void first_add() {
+    public void first_add() {
         First sum1 = new First(5);
         First sum2 = new First(2);
         First sum3 = new First(221112);


### PR DESCRIPTION
## Summary

I followed [this guide](https://natritmeyer.com/howto/reporting-aggregated-unit-and-integration-test-coverage-with-jacoco/), which describes a similar case. 

With the current setup, the coverage from the "unit-tests" execution will override the coverage from "default-tests" execution because all of them write to `jacoco.exec` file. This setup ensures that each execution generates a dedicated JaCoCo report. Single reports can be merged into a single one if needed. See "Merging unit and integration test coverage data" in the guide I linked.